### PR TITLE
落穂拾いの修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,19 +2,6 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
 
-  # 落穂拾い
-  rescue_from Exception, with: :error500
-  rescue_from ActiveRecord::RecordNotFound, ActionController::RoutingError, with: :error404
-
-  def error404(_e)
-    render 'error404', status: 404, formats: [:html]
-  end
-
-  def error500(e)
-    logger.error [e, *e.backtrace].join("\n")
-    render 'error500', status: 500, formats: [:html]
-  end
-
   private
 
   def configure_permitted_parameters

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,17 @@
+class ErrorsController < ApplicationController
+  rescue_from Exception, with: :error500
+  rescue_from ActiveRecord::RecordNotFound, ActionController::RoutingError, with: :error404
+
+  def error404(_e)
+    render 'error404', status: 404, formats: [:html]
+  end
+
+  def error500(e)
+    logger.error [e, *e.backtrace].join("\n")
+    render 'error500', status: 500, formats: [:html]
+  end
+
+  def error
+    raise
+  end
+end

--- a/app/views/application/error404.html.erb
+++ b/app/views/application/error404.html.erb
@@ -1,1 +1,3 @@
-ご指定になったページは存在しません
+<%= render 'shared/header' %>
+<p>ご指定になったページは存在しません</p>
+<%= render 'shared/footer' %>

--- a/app/views/application/error500.html.erb
+++ b/app/views/application/error500.html.erb
@@ -1,1 +1,3 @@
-エラーが発生しました
+<%= render 'shared/header' %>
+<p>エラーが発生しました</p>
+<%= render 'shared/footer' %>

--- a/config/initializers/exceptions_app.rb
+++ b/config/initializers/exceptions_app.rb
@@ -1,0 +1,1 @@
+Rails.configuration.exceptions_app = ErrorsController.action(:error)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,4 @@ Rails.application.routes.draw do
   resources :retirements, only: [:new, :create]
   resources :searches, only: :index 
 
-  # 落穂拾い用に全てのURLをキャッチ
-  match "*path" => "application#error404", via: :all
 end


### PR DESCRIPTION
# What
エラーハンドリングの修正
# Why
- /config/route.rbが/activestorage/config/routes.rbよりも先に呼ばれ、画像を呼ぶ前に、エラーページを表示していた問題を修正
- errors_controllerを作成し、resque_formで拾えないエラーメッセージはexceptions_appで処理